### PR TITLE
Fix image gallery component

### DIFF
--- a/src/components/gallery-img.js
+++ b/src/components/gallery-img.js
@@ -28,11 +28,13 @@ const GalleryImg = function (props) {
           }
         }
       `}
-      render={({ images }) =>
-        renderImage(
-          images.edges.find(image => image.node.relativePath === props.src)
-        )
-      }
+      render={({ images }) => {
+        const image = images.edges.find(image => image.node.relativePath === props.src);
+        if (!image) {
+          return <div style={{ color: `red` }}>Cannot find image: {props.src}</div>;
+        }
+        return renderImage(image);
+      }}
     />
   )
 }

--- a/src/pages/hall-hire.js
+++ b/src/pages/hall-hire.js
@@ -31,14 +31,14 @@ const HallHirePage = () => (
     <h2 className="center">Hall Hire Gallery</h2>
 
     <div className="two-col-gallery-grid">
-        <GalleryImg src={`images/HLCCHL-Hall-Hire-1.jpg`} />
-        <GalleryImg src={`images/HLCCHL-Hall-Hire-2.jpg`} />
-        <GalleryImg src={`images/HLCCHL-Hall-Hire-3.jpg`} />
-        <GalleryImg src={`images/HLCCHL-Hall-Hire-4.jpg`} />
-        <GalleryImg src={`images/HLCCHL-Hall-Hire-9.jpg`} />
-        <GalleryImg src={`images/HLCCHL-Hall-Hire-6.jpg`} />
-        <GalleryImg src={`images/HLCCHL-Hall-Hire-7.jpg`} />
-        <GalleryImg src={`images/HLCCHL-Hall-Hire-8.jpeg`} />
+        <GalleryImg src={`HLCCHL-Hall-Hire-1.jpg`} />
+        <GalleryImg src={`HLCCHL-Hall-Hire-2.jpg`} />
+        <GalleryImg src={`HLCCHL-Hall-Hire-3.jpg`} />
+        <GalleryImg src={`HLCCHL-Hall-Hire-4.jpg`} />
+        <GalleryImg src={`HLCCHL-Hall-Hire-9.jpg`} />
+        <GalleryImg src={`HLCCHL-Hall-Hire-6.jpg`} />
+        <GalleryImg src={`HLCCHL-Hall-Hire-7.jpg`} />
+        <GalleryImg src={`HLCCHL-Hall-Hire-8.jpeg`} />
     </div>
 
   </LayoutPage>


### PR DESCRIPTION
Looks like you're passing in `images/HLCCHL-Hall-Hire-1.jpg` to your component, but Gatsby see's these images as `HLCCHL-Hall-Hire-1.jpg` instead. Note that it does not start with `images/`.

* * *

The next issue is that you're trying to use `<GalleryImg src={`images/HLCCHL-Hall-Hire-9.jpg`} />` (which I assume is supposed to be 5 instead of 9), as there is no image number 9. This then causes the `Cannot read property 'node' of undefined` error because it's trying to use `undefined` as if it were an image.

I have fixed this by adding a simple check in to make sure an image exists before trying to use it. It will output a message saying "cannot find image" if the image does not exist. You could probably make this look much better ;)